### PR TITLE
fix: add_options_page numeric parameter for capability is deprecated

### DIFF
--- a/wp-require-login.php
+++ b/wp-require-login.php
@@ -47,7 +47,7 @@ add_action('admin_notices', 'rl_post_install');
 add_action('admin_menu', 'rl_menu');
 
 function rl_menu() {
-    add_options_page('Require Login', 'Require Login', 8, 'require_login', 'require_login');
+    add_options_page('Require Login', 'Require Login', 'manage_options', 'require_login', 'require_login');
 }
 
 function require_login() {


### PR DESCRIPTION
Using 'manage_options' instead of 8 as the capability parameter of add_options_page fixes some issues when WP_DEBUG is enabled.

Please consider updating the official version on the WordPress repository if you have a chance. Thanks for this plugin
